### PR TITLE
Specify UTF-8 when reading version file

### DIFF
--- a/zrom_cleaner.py
+++ b/zrom_cleaner.py
@@ -3,9 +3,18 @@
 import sys
 from pathlib import Path
 
+
+def _get_version() -> str:
+    """Return the application version string."""
+    version_path = Path(__file__).with_name("VERSION.txt")
+    return version_path.read_text(encoding="utf-8").strip()  # use UTF-8 encoding
+
+
 def main():
     # placeholder for the full script; users can replace with the latest
     print("ZRom Cleaner skeleton script is bundled. Replace with your full zrom_cleaner.py if needed.")
     print("Run: python zrom_cleaner.py /path/to/roms --regions U E UK J W --apply")
+
+
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- add a helper to read VERSION.txt
- specify UTF-8 encoding when reading the version

## Testing
- `python -m py_compile zrom_cleaner.py`


------
https://chatgpt.com/codex/tasks/task_e_68c51f59b7248333bccbe7b11405d1bd