### PR TITLE
Prompt for directory when no path provided

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,3 +122,12 @@ If you like the terminal, you can run it there too.
 python zrom_cleaner.py
 python zrom_cleaner.py D:\Roms --regions U E UK J W --report report.csv
 python zrom_cleaner.py D:\Roms --regions U E UK J W --keep-original-pair --apply
+```
+
+Example session when no path is supplied:
+
+```bash
+$ python zrom_cleaner.py
+Enter ROM directory (leave blank for current directory):
+Using ROM directory: /current/directory
+```

--- a/zrom_cleaner.py
+++ b/zrom_cleaner.py
@@ -2,10 +2,30 @@
 # minimal entry calling GUI if no args else CLI
 import sys
 from pathlib import Path
+import argparse
 
-def main():
+
+def main(argv=None):
+    """Minimal CLI entry point.
+
+    When no path argument is supplied, the user is prompted for one. An
+    empty response defaults to the current working directory.
+    """
+    parser = argparse.ArgumentParser(description="ZRom Cleaner skeleton")
+    parser.add_argument("path", nargs="?", help="Directory containing ROMs")
+    args = parser.parse_args(argv)
+
+    if args.path is None:
+        response = input("Enter ROM directory (leave blank for current directory): ").strip()
+        args.path = Path(response) if response else Path.cwd()
+    else:
+        args.path = Path(args.path)
+
     # placeholder for the full script; users can replace with the latest
-    print("ZRom Cleaner skeleton script is bundled. Replace with your full zrom_cleaner.py if needed.")
+    print(
+        "ZRom Cleaner skeleton script is bundled. Replace with your full zrom_cleaner.py if needed."
+    )
     print("Run: python zrom_cleaner.py /path/to/roms --regions U E UK J W --apply")
+    print(f"Using ROM directory: {args.path}")
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- Prompt user for ROM directory when no path argument is supplied
- Document the interactive prompt with an example session

## Testing
- `python -m py_compile zrom_cleaner.py`
- `printf '\n' | python zrom_cleaner.py`


------
https://chatgpt.com/codex/tasks/task_e_68c5219af9e08333a5a8b40f5ff1b0fa