### PR TITLE
feat: add config file support

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,3 +122,22 @@ If you like the terminal, you can run it there too.
 python zrom_cleaner.py
 python zrom_cleaner.py D:\Roms --regions U E UK J W --report report.csv
 python zrom_cleaner.py D:\Roms --regions U E UK J W --keep-original-pair --apply
+```
+
+### Configuration File
+
+Default options may be stored in a JSON or INI file and supplied with
+`--config`:
+
+```bash
+python zrom_cleaner.py --config assets/sample_config.json
+```
+
+Values from the configuration file act as defaults. Any flags specified on
+the command line take precedence over the file. The order of precedence is:
+
+1. Explicit command line flags
+2. Values in the config file
+3. Built-in defaults
+
+Sample configuration files can be found in the `assets/` directory.

--- a/assets/sample_config.ini
+++ b/assets/sample_config.ini
@@ -1,0 +1,6 @@
+[DEFAULT]
+path = /path/to/roms
+regions = U E UK J W
+report = report.csv
+keep_original_pair = true
+apply = false

--- a/assets/sample_config.json
+++ b/assets/sample_config.json
@@ -1,0 +1,7 @@
+{
+  "path": "/path/to/roms",
+  "regions": ["U", "E", "UK", "J", "W"],
+  "report": "report.csv",
+  "keep_original_pair": true,
+  "apply": false
+}

--- a/zrom_cleaner.py
+++ b/zrom_cleaner.py
@@ -1,11 +1,115 @@
 #!/usr/bin/env python3
-# minimal entry calling GUI if no args else CLI
+"""Minimal entry calling GUI if no args else CLI.
+
+This skeleton focuses on demonstrating command line parsing. The real
+project uses a far more feature rich script. Replace this file with the
+latest ``zrom_cleaner.py`` if you need the full application.
+"""
+
+import argparse
+import configparser
+import json
 import sys
 from pathlib import Path
+from typing import Any, Dict, List
 
-def main():
+
+def _build_parser() -> argparse.ArgumentParser:
+    """Create the CLI argument parser.
+
+    A ``--config`` option is available to load defaults from a JSON or INI
+    file. Values provided explicitly on the command line override those
+    found in the configuration file.
+    """
+
+    parser = argparse.ArgumentParser(description="ZRom Cleaner CLI")
+    parser.add_argument("path", nargs="?", help="ROM directory", default=None)
+    parser.add_argument(
+        "--regions",
+        nargs="+",
+        help="Region priority, e.g. U E UK J W",
+    )
+    parser.add_argument("--report", help="Write CSV report to file")
+    parser.add_argument(
+        "--keep-original-pair",
+        action="store_true",
+        help="Keep original paired with best revision",
+    )
+    parser.add_argument("--apply", action="store_true", help="Apply changes")
+    parser.add_argument(
+        "--config", help="Path to JSON or INI config file providing defaults"
+    )
+    return parser
+
+
+def _load_config(config_path: str) -> Dict[str, Any]:
+    """Load configuration values from *config_path*.
+
+    Supports either JSON or INI files. Values are returned as a dictionary
+    keyed by the parser's destination names.
+    """
+
+    data: Dict[str, Any] = {}
+    path = Path(config_path)
+    if not path.exists():
+        return data
+
+    try:
+        if path.suffix.lower() == ".json":
+            data = json.loads(path.read_text())
+        else:
+            parser = configparser.ConfigParser()
+            parser.read(path)
+            section = parser.sections()[0] if parser.sections() else parser.default_section
+            data = dict(parser[section])
+    except Exception:
+        # If the config fails to load we simply ignore it and fall back to
+        # command line defaults.
+        return {}
+
+    # Normalise known options
+    if "regions" in data and isinstance(data["regions"], str):
+        # Split on whitespace to form a list of region codes
+        data["regions"] = data["regions"].split()
+
+    for flag in ["keep_original_pair", "apply"]:
+        if flag in data:
+            value = str(data[flag]).lower()
+            data[flag] = value in {"1", "true", "yes", "on"}
+
+    return data
+
+
+def _parse_args(argv: List[str]) -> argparse.Namespace:
+    """Parse command line arguments, merging config file values."""
+
+    parser = _build_parser()
+    # First parse just to discover --config
+    preliminary, _ = parser.parse_known_args(argv)
+
+    config: Dict[str, Any] = {}
+    if preliminary.config:
+        config = _load_config(preliminary.config)
+        if config:
+            # Only apply config keys that match known parser destinations
+            valid = {action.dest for action in parser._actions}
+            parser.set_defaults(**{k: v for k, v in config.items() if k in valid})
+
+    return parser.parse_args(argv)
+
+
+def main(argv: List[str] | None = None) -> None:
     # placeholder for the full script; users can replace with the latest
-    print("ZRom Cleaner skeleton script is bundled. Replace with your full zrom_cleaner.py if needed.")
+    args = _parse_args(argv or sys.argv[1:])
+    print(
+        "ZRom Cleaner skeleton script is bundled. Replace with your full"
+        " zrom_cleaner.py if needed."
+    )
+    print("Parsed arguments:")
+    for key, value in vars(args).items():
+        print(f"  {key}: {value}")
     print("Run: python zrom_cleaner.py /path/to/roms --regions U E UK J W --apply")
+
+
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- add `--config` option and merge JSON/INI config with CLI arguments
- document configuration file precedence and include sample configs

## Testing
- `python -m py_compile zrom_cleaner.py`
- `python zrom_cleaner.py --help`
- `python zrom_cleaner.py --config assets/sample_config.json`
- `python zrom_cleaner.py --config assets/sample_config.ini --apply --regions X Y`
- `python zrom_cleaner.py /override --config assets/sample_config.json`


------
https://chatgpt.com/codex/tasks/task_e_68c5219bd0b48333b05b8640a9e9ba6d