### PR TITLE
Use UTF-8 when reading version

### DIFF
--- a/zrom_cleaner.py
+++ b/zrom_cleaner.py
@@ -3,6 +3,13 @@
 import sys
 from pathlib import Path
 
+
+def _get_version() -> str:
+    """Return the application version string."""
+    version_file = Path(__file__).with_name("VERSION.txt")
+    # Use UTF-8 to ensure consistent decoding across platforms
+    return version_file.read_text(encoding="utf-8").strip()
+
 def main():
     # placeholder for the full script; users can replace with the latest
     print("ZRom Cleaner skeleton script is bundled. Replace with your full zrom_cleaner.py if needed.")


### PR DESCRIPTION
## Summary
- Read version file with explicit UTF-8 encoding

## Testing
- `python -m py_compile zrom_cleaner.py`


------
https://chatgpt.com/codex/tasks/task_e_68c52330c4248333965eeb5880a8c2cc