### PR TITLE
Add unified release script and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,3 +122,14 @@ If you like the terminal, you can run it there too.
 python zrom_cleaner.py
 python zrom_cleaner.py D:\Roms --regions U E UK J W --report report.csv
 python zrom_cleaner.py D:\Roms --regions U E UK J W --keep-original-pair --apply
+```
+
+## Build Release Archives
+
+Run the helper script to build and package the app for your platform:
+
+```bash
+./make_release.sh
+```
+
+The script detects whether you are on macOS or Windows and runs the appropriate build and packaging steps, placing the resulting zip file in the `release/` directory.

--- a/make_release.sh
+++ b/make_release.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+OS="$(uname -s)"
+case "$OS" in
+    Darwin)
+        echo "Building macOS release"
+        ./build_mac_icon.sh
+        ./package_mac.sh
+        ;;
+    MINGW*|MSYS*|CYGWIN*|Windows_NT)
+        echo "Building Windows release"
+        cmd.exe /c build_windows_icon.bat
+        cmd.exe /c package_windows.bat
+        ;;
+    *)
+        echo "Unsupported OS: $OS" >&2
+        exit 1
+        ;;
+esac


### PR DESCRIPTION
## Summary
- Add `make_release.sh` to detect platform and run appropriate build and packaging steps
- Document how to build release archives using the new script

## Testing
- `bash -n make_release.sh`
- `./make_release.sh` *(fails: Unsupported OS: Linux)*

------
https://chatgpt.com/codex/tasks/task_e_68c523534e4083339b1e16297162a10e