### PR TITLE
Add script existence check to Windows build process

### DIFF
--- a/build_windows_icon.bat
+++ b/build_windows_icon.bat
@@ -1,3 +1,13 @@
 @echo off
+rem Verify required files exist before building
+if not exist assets\zrom.ico (
+    echo Error: icon file assets\zrom.ico not found.
+    exit /b 1
+)
+rem Ensure main script is present
+if not exist zrom_cleaner.py (
+    echo Error: zrom_cleaner.py not found.
+    exit /b 1
+)
 python -m pip install --upgrade pip pyinstaller
 pyinstaller --onefile --windowed --name ZRomCleaner --icon assets\zrom.ico zrom_cleaner.py


### PR DESCRIPTION
## Summary
- verify required icon and script exist before invoking PyInstaller

## Testing
- `python -m py_compile zrom_cleaner.py`
- `python zrom_cleaner.py --help`


------
https://chatgpt.com/codex/tasks/task_e_68c52349b130833397a4c1fa0a433d7c