### PR TITLE
Prompt for directory when path argument is missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,3 +122,12 @@ If you like the terminal, you can run it there too.
 python zrom_cleaner.py
 python zrom_cleaner.py D:\Roms --regions U E UK J W --report report.csv
 python zrom_cleaner.py D:\Roms --regions U E UK J W --keep-original-pair --apply
+```
+
+Example interaction when no path is provided:
+
+```
+$ python zrom_cleaner.py
+Enter ROM directory [current directory]:
+Validated path: /home/user/roms
+```

--- a/zrom_cleaner.py
+++ b/zrom_cleaner.py
@@ -1,11 +1,61 @@
 #!/usr/bin/env python3
-# minimal entry calling GUI if no args else CLI
-import sys
-from pathlib import Path
+"""Minimal command line entry point for ZRom Cleaner."""
 
-def main():
+import argparse
+from pathlib import Path
+from typing import Optional
+
+
+def _validate_path(path_str: str) -> Path:
+    """Validate that ``path_str`` points to an existing directory.
+
+    Args:
+        path_str: String representation of the path provided by the user.
+
+    Returns:
+        A resolved :class:`~pathlib.Path` instance.
+
+    Raises:
+        FileNotFoundError: If the path does not exist.
+        NotADirectoryError: If the path exists but is not a directory.
+    """
+
+    path = Path(path_str).expanduser().resolve()
+    if not path.exists():
+        raise FileNotFoundError(f"Path does not exist: {path}")
+    if not path.is_dir():
+        raise NotADirectoryError(f"Not a directory: {path}")
+    return path
+
+
+def _parse_args(argv: Optional[list[str]] = None) -> argparse.Namespace:
+    """Parse command line arguments."""
+
+    parser = argparse.ArgumentParser(description="ZRom Cleaner skeleton script")
+    parser.add_argument("path", nargs="?", help="Directory containing ROMs to clean")
+    return parser.parse_args(argv)
+
+
+def main(argv: Optional[list[str]] = None) -> None:
+    """Entry point used by the command line interface."""
+
+    args = _parse_args(argv)
+    path_str = args.path
+    if path_str is None:
+        # Prompt the user for a directory if no path argument was supplied.
+        path_str = input("Enter ROM directory [current directory]: ").strip()
+        if path_str == "":
+            path_str = "."
+
+    path = _validate_path(path_str)
+
     # placeholder for the full script; users can replace with the latest
-    print("ZRom Cleaner skeleton script is bundled. Replace with your full zrom_cleaner.py if needed.")
+    print(
+        "ZRom Cleaner skeleton script is bundled. Replace with your full zrom_cleaner.py if needed."
+    )
     print("Run: python zrom_cleaner.py /path/to/roms --regions U E UK J W --apply")
+    print(f"Validated path: {path}")
+
+
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- Prompt for ROM directory when no path is supplied and validate it
- Document example interactive session in README

## Testing
- `python -m pytest`
- `printf '\n' | python zrom_cleaner.py`


------
https://chatgpt.com/codex/tasks/task_e_68c5233d80c883338b7006a1b8e8d127